### PR TITLE
Handle someone pressing the Home button or putting the 3DS to sleep m…

### DIFF
--- a/source/3dsexit.cpp
+++ b/source/3dsexit.cpp
@@ -2,17 +2,38 @@
 #include <3ds.h>
 
 #include "3dsexit.h"
+#include "3dsgpu.h"
+#include "3dssound.h"
+#include "memmap.h"
+#include "snes9x.h"
 
 aptHookCookie hookCookie;
 int appExiting = 0;
+int appSuspended = 0;
 
-void setExitFlag(APT_HookType hook, void* param)
+void handleAptHook(APT_HookType hook, void* param)
 {
-    if (hook == APTHOOK_ONEXIT) {
-        appExiting = 1;
+    switch (hook) {
+        case APTHOOK_ONEXIT:
+            appExiting = 1;
+            break;
+        case APTHOOK_ONSUSPEND:
+        case APTHOOK_ONSLEEP:
+            appSuspended = 1;
+            if (GPU3DS.emulatorState == EMUSTATE_EMULATE) {
+                snd3dsStopPlaying();
+                if (CPU.SRAMModified || CPU.AutoSaveTimer) {
+                    S9xAutoSaveSRAM();
+                }
+            }
+            break;
+        case APTHOOK_ONRESTORE:
+        case APTHOOK_ONWAKEUP:
+            appSuspended = 1;
+            break;
     }
 }
 
-void enableExitHook() {
-    aptHook(&hookCookie, setExitFlag, NULL);
+void enableAptHooks() {
+    aptHook(&hookCookie, handleAptHook, NULL);
 }

--- a/source/3dsexit.h
+++ b/source/3dsexit.h
@@ -5,8 +5,9 @@
 
 extern aptHookCookie hookCookie;
 extern int appExiting;
+extern int appSuspended;
 
-void setExitFlag(APT_HookType hook, void* param);
-void enableExitHook();
+void handleAptHook(APT_HookType hook, void* param);
+void enableAptHooks();
 
 #endif

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -1118,7 +1118,7 @@ void emulatorInitialize()
 
     osSetSpeedupEnable(1);    // Performance: use the higher clock speed for new 3DS.
 
-    enableExitHook();
+    enableAptHooks();
 
     settingsLoad(false);
 
@@ -1253,6 +1253,7 @@ void emulatorLoop()
     long snesFrameTotalAccurateTicks = 0;
 
     bool firstFrame = true;
+    appSuspended = 0;
 
     snd3DS.generateSilence = false;
 
@@ -1284,7 +1285,7 @@ void emulatorLoop()
         startFrameTick = svcGetSystemTick();
         aptMainLoop();
 
-        if (appExiting)
+        if (appExiting || appSuspended)
             break;
 
         gpu3dsCheckSlider();


### PR DESCRIPTION
…ore gracefully by stopping the sound emulation, saving the SRAM, and forcing the emulation to reinitialize when resuming. This fixes the video emulation breaking until you open and close the emulator menu, and might fix #5, though I'm not 100% sure about that one.